### PR TITLE
Fix overlinking.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,4 +19,4 @@ libsonic_hal_routing_la_CXXFLAGS=-std=c++11
 
 libsonic_hal_routing_la_LDFLAGS=-shared -version-info 1:1:0
 
-libsonic_hal_routing_la_LIBADD=-lsonic_nas_linux -lsonic_common -lsonic_nas_ndi -lsonic_object_library -lsonic_cps_class_map -lsonic_logging -lcrypto
+libsonic_hal_routing_la_LIBADD=-lsonic_nas_linux -lsonic_common -lsonic_nas_ndi -lsonic_object_library -lsonic_logging -lcrypto


### PR DESCRIPTION
Remove -lsonic_cps_class_map from libsonic_hal_routing_la_LIBADD.